### PR TITLE
#231-update item-descr fw

### DIFF
--- a/src/containers/guest-home-page/cards-with-button/CardsWithButton.tsx
+++ b/src/containers/guest-home-page/cards-with-button/CardsWithButton.tsx
@@ -53,7 +53,7 @@ const CardsWithButton: FC<CardsWithButtonProps> = ({
           <TitleWithDescription
             description={
               <Typography variant='body2'>
-                {t(item.description as string)}
+                {t(item.description || "")}
               </Typography>
             }
             style={styles[boxSide]}

--- a/src/containers/guest-home-page/cards-with-button/CardsWithButton.tsx
+++ b/src/containers/guest-home-page/cards-with-button/CardsWithButton.tsx
@@ -8,6 +8,7 @@ import Box from '@mui/material/Box'
 import AppButton from '~/components/app-button/AppButton'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import dots from '~/assets/img/guest-home-page/dots.svg'
+import Typography from '@mui/material/Typography'
 
 import {
   AccordionWithImageItem,
@@ -50,7 +51,11 @@ const CardsWithButton: FC<CardsWithButtonProps> = ({
             <Box className='dots' component='img' src={dots} />
           </Box>
           <TitleWithDescription
-            description={t(item.description)}
+            description={
+              <Typography variant='body2'>
+                {t(item.description as string)}
+              </Typography>
+            }
             style={styles[boxSide]}
             title={t(item.title)}
           />


### PR DESCRIPTION
updated item description font-weight, changing variant style from 'subtitle2' to 'body2'.

previous result: 
<img width="1141" height="599" alt="image" src="https://github.com/user-attachments/assets/c951a9b6-fed1-41fd-8c1d-db3e55a4866e" />
actual result:
<img width="1141" height="599" alt="image" src="https://github.com/user-attachments/assets/611bb5d1-f6a5-4a1a-8515-43822963bdec" />

