### PR TITLE
Bud fix 30 email field

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -23,7 +23,7 @@
   },
   "whatCanYouDo": {
     "title": "What can you do",
-    "description": "Whether you’re looking for a tutor or to looking become one – you’ve come to the right place.",
+    "description": "Whether you’re looking for a tutor or looking to become one – you’ve come to the right place.",
     "learn": {
       "title": "Learn from experts",
       "description": "Learning from experts is a shortcut to mastery. Their knowledge and experience can guide you, unlocking your potential. Don't put off until tomorrow. Embrace it! 🌟",

--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
@@ -83,7 +83,7 @@ const ForgotPassword = () => {
         style={styles.titleWithDescription}
         title={t('login.forgotPassword')}
       />
-
+<Box sx={{ mb: 4 }} />
       <Box component='form' onSubmit={handleSubmit}>
         <AppTextField
           autoFocus


### PR DESCRIPTION
The “Email” input field is overlapped by description text on the password reset pop-up fixed